### PR TITLE
Draft of data patching system

### DIFF
--- a/fakemon/fakemon.lua
+++ b/fakemon/fakemon.lua
@@ -2,7 +2,6 @@ local defsave = require "defsave.defsave"
 local settings = require "pokedex.settings"
 local log = require "utils.log"
 local flow = require "utils.flow"
-local defsave = require "defsave.defsave"
 local zzlib = require "utils.zzlib"
 local file = require "utils.file"
 

--- a/main/main.collection
+++ b/main/main.collection
@@ -435,6 +435,7 @@ embedded_instances {
   children: "move_info"
   children: "moves_scrollist"
   children: "natures_scrollist"
+  children: "patch"
   children: "pick_name"
   children: "pokedex_pokemon"
   children: "random_pokemon"
@@ -1985,6 +1986,69 @@ embedded_instances {
   "  type: \"collectionfactory\"\n"
   "  data: \"prototype: \\\"/screens/trainer/trainer.collection\\\"\\n"
   "load_dynamically: true\\n"
+  "\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}
+embedded_instances {
+  id: "patch"
+  data: "components {\n"
+  "  id: \"screen_factory\"\n"
+  "  component: \"/monarch/screen_factory.script\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"screen_id\"\n"
+  "    value: \"patch\"\n"
+  "    type: PROPERTY_TYPE_HASH\n"
+  "  }\n"
+  "  properties {\n"
+  "    id: \"popup\"\n"
+  "    value: \"true\"\n"
+  "    type: PROPERTY_TYPE_BOOLEAN\n"
+  "  }\n"
+  "}\n"
+  "embedded_components {\n"
+  "  id: \"collectionfactory\"\n"
+  "  type: \"collectionfactory\"\n"
+  "  data: \"prototype: \\\"/screens/popups/patch/patch.collection\\\"\\n"
+  "load_dynamically: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/main.script
+++ b/main/main.script
@@ -126,6 +126,8 @@ function init(self)
 			flow.until_true(function() return not fakemon.BUSY end)
 		end
 		patch.init()
+		flow.until_true(function() return not patch.is_busy end)
+		
 		movedex.init()
 		natures.init()
 		pokedex.init()

--- a/main/main.script
+++ b/main/main.script
@@ -125,6 +125,7 @@ function init(self)
 			fakemon.init()
 			flow.until_true(function() return not fakemon.BUSY end)
 		end
+		patch.init()
 		movedex.init()
 		natures.init()
 		pokedex.init()
@@ -139,7 +140,6 @@ function init(self)
 		items.init()
 		filters.init()
 		feats.init()
-		patch.init()
 
 		if profiles.is_new_game() then 
 			monarch.show("pick_name", nil, {sender=msg.url(), slot=1})

--- a/main/main.script
+++ b/main/main.script
@@ -8,6 +8,7 @@ local dex = require "pokedex.dex"
 local items = require "pokedex.items"
 local feats = require "pokedex.feats"
 local storage = require "pokedex.storage"
+local patch = require "pokedex.patch"
 local profiles = require "pokedex.profiles"
 local filters = require "pokedex.filters"
 local trainer = require "pokedex.trainer"
@@ -138,7 +139,7 @@ function init(self)
 		items.init()
 		filters.init()
 		feats.init()
-		
+		patch.init()
 
 		if profiles.is_new_game() then 
 			monarch.show("pick_name", nil, {sender=msg.url(), slot=1})

--- a/pokedex/natures.lua
+++ b/pokedex/natures.lua
@@ -52,8 +52,6 @@ function M.init()
 			end
 		end
 		M.list, M.total = list()
-
-		patch.register_patch_key(patch_key)
 		
 		initialized = true
 	end

--- a/pokedex/natures.lua
+++ b/pokedex/natures.lua
@@ -27,6 +27,10 @@ function M.is_nature(nature)
 	return M.get_nature_attributes(nature) and true or false
 end
 
+function M.get_nature_display(nature)
+	return patch.get_patch_data(patch_key, {nature, "DisplayName"}) or nature
+end
+
 function M.get_nature_attributes(nature)
 	if natures[nature] then
 		return natures[nature]

--- a/pokedex/natures.lua
+++ b/pokedex/natures.lua
@@ -48,44 +48,8 @@ function M.init()
 			end
 		end
 		M.list, M.total = list()
-		
-		local nature_keys = {}
-		local modifier_keys_seen = {}
-		local modifier_keys = {}
-		for n_k, n_v in pairs(natures) do
-			table.insert(nature_keys, n_k)
-			for a_k,_ in pairs(n_v) do
-				if modifier_keys_seen[a_k] == nil then
-					modifier_keys_seen[a_k] = true
-					table.insert(modifier_keys, a_k)
-				end
-			end
-		end
-		table.sort(modifier_keys)
 
-		local schema =
-		{
-			type = "table",
-			keys = nature_keys,
-			value_type = "table",
-			values =
-			{
-				DisplayName = 
-				{
-					type = "string",
-					name = "Display Name",
-				},
-				Attributes =
-				{
-					type = "table",
-					keys = modifier_keys,
-					value_type = "number",
-				},
-			},
-		}
-
-		print("Nature Schema:")
-		patch.dump_schema(schema)
+		patch.register_patch_key(patch_key)
 		
 		initialized = true
 	end

--- a/pokedex/natures.lua
+++ b/pokedex/natures.lua
@@ -1,11 +1,13 @@
 local file = require "utils.file"
 local log = require "utils.log"
 local fakemon = require "fakemon.fakemon"
+local patch = require "pokedex.patch"
 
 local M = {}
 
 local initialized = false
 local natures
+local patch_key = "Nature"
 
 local function list()
 	local temp_list = {}
@@ -46,9 +48,47 @@ function M.init()
 			end
 		end
 		M.list, M.total = list()
+		
+		local nature_keys = {}
+		local modifier_keys_seen = {}
+		local modifier_keys = {}
+		for n_k, n_v in pairs(natures) do
+			table.insert(nature_keys, n_k)
+			for a_k,_ in pairs(n_v) do
+				if modifier_keys_seen[a_k] == nil then
+					modifier_keys_seen[a_k] = true
+					table.insert(modifier_keys, a_k)
+				end
+			end
+		end
+		table.sort(modifier_keys)
+
+		local schema =
+		{
+			type = "table",
+			keys = nature_keys,
+			value_type = "table",
+			values =
+			{
+				DisplayName = 
+				{
+					type = "string",
+					name = "Display Name",
+				},
+				Attributes =
+				{
+					type = "table",
+					keys = modifier_keys,
+					value_type = "number",
+				},
+			},
+		}
+
+		print("Nature Schema:")
+		patch.dump_schema(schema)
+		
 		initialized = true
 	end
 end
-
 
 return M

--- a/pokedex/patch.lua
+++ b/pokedex/patch.lua
@@ -12,7 +12,6 @@ local M = {}
 M.is_busy = false
 
 local initialized = false
-local patch_data_keys = {}
 local patch_data
 local patch_data_compiled
 
@@ -49,12 +48,12 @@ local function download_all_patches()
 				http.request(this_patch_data.url, "GET", function(self, id, res)
 					if res.status == 200 or res.status == 304 then
 						this_patch_data.data = json.decode(res.response)	
-						this_patch_data.last_download_success = os.date()
+						this_patch_data.last_download_success = os.time()
 						this_patch_data.error = nil
 					else
 						this_patch_data.error = tostring(res.status) .. ": " .. tostring(res.response)
 					end
-					this_patch_data.last_download_attempt = os.date()
+					this_patch_data.last_download_attempt = os.time()
 					num_to_download = num_to_download - 1
 				end)
 			end
@@ -82,6 +81,34 @@ function M.init()
 					},
 					{
 						enabled = true,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
+						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
+					},
+					{
+						enabled = false,
 						url = "https://raw.githubusercontent.com/magroader/Pokemon5EPatchExample/master/speed_adjust.json",
 					},
 				}
@@ -113,11 +140,24 @@ function M.get_patch_data(key, path)
 	return nil
 end
 
-function M.get_patch_names()
+function M.get_all_patch_data_details()
 	local ret = {}
-	for i=1, #patch_data, 1 do
-		table.insert(ret, patch_data[i].name)
+	
+	for i=1, #patch_data do
+		local this_details = {}
+		table.insert(ret, this_details)
+		
+		local this_data = patch_data[i]
+		this_details.url = this_data.url
+		this_details.last_download_success = this_data.last_download_success
+		this_details.enabled = this_data.enabled
+		if this_data.data ~= nil then
+			this_details.name = this_data.data.name
+			this_details.description = this_data.data.description
+			this_details.author = this_data.data.author
+		end		
 	end
+
 	return ret
 end
 

--- a/pokedex/patch.lua
+++ b/pokedex/patch.lua
@@ -14,6 +14,7 @@ function M.init()
 	-- TEMP, example data that could be loaded up
 	table.insert(patch_data, {
 		name = "Patch 1",
+		enabled = true,
 		data = {
 			Nature = {
 				Dumb = {
@@ -25,10 +26,23 @@ function M.init()
 	
 	table.insert(patch_data, {
 		name = "Patch 2",
+		enabled = true,
 		data = {
 			Nature = {
 				Dumb = {
 					DisplayName = "Quiet"
+				}
+			}
+		}
+	})
+
+	table.insert(patch_data, {
+		name = "Patch 3",
+		enabled = false,
+		data = {
+			Nature = {
+				Dumb = {
+					DisplayName = "Bananas"
 				}
 			}
 		}
@@ -72,16 +86,17 @@ function M.get_patch_data(key, path)
 	end
 	
 	for i=#patch_data, 1, -1 do
-		
-		local current = patch_data[i].data[key]
-		for j=1,#path do
-			if current == nil then
-				break
+		if patch_data[i].enabled then
+			local current = patch_data[i].data[key]
+			for j=1,#path do
+				if current == nil then
+					break
+				end
+				current = current[path[j]]
 			end
-			current = current[path[j]]
-		end
-		if current ~= nil then
-			return current
+			if current ~= nil then
+				return current
+			end
 		end
 	end
 	return nil

--- a/pokedex/patch.lua
+++ b/pokedex/patch.lua
@@ -1,0 +1,149 @@
+local log = require "utils.log"
+
+local M = {}
+
+local initialized = false
+local patch_data_schema = {}
+local patch_data = {}
+
+function M.init()
+	if not initialized then
+		initialized = true
+	end
+
+	-- TEMP, example data that could be loaded up
+	table.insert(patch_data, {
+		name = "Patch 1",
+		data = {
+			Nature = {
+				Dumb = {
+					DisplayName = "Silly"
+				}
+			}
+		}
+	})
+	
+	table.insert(patch_data, {
+		name = "Patch 2",
+		data = {
+			Nature = {
+				Dumb = {
+					DisplayName = "Quiet"
+				}
+			}
+		}
+	})
+end
+
+function M.register_patch_schema(key, schema)
+	if initialized then
+		local e = string.format("Cannot add patch key after initialization: '%s'", tostring(key)) ..  "\n" .. debug.traceback()
+		gameanalytics.addErrorEvent {
+			severity = "Error",
+			message = e
+		}
+		log.error(e)
+		return false
+	end
+	if patch_data_schema[key] ~= nil then
+		local e = string.format("Already tried to register patch key: '%s'", tostring(key)) ..  "\n" .. debug.traceback()
+		gameanalytics.addErrorEvent {
+			severity = "Error",
+			message = e
+		}
+		log.error(e)
+		return false
+	end
+
+	patch_data_schema[key] = schema
+	
+	return true
+end
+
+function M.get_patch_data(key, path)
+	if patch_data_schema[key] == nil then
+		local e = string.format("Tried to get patch data for a key that was not registered: '%s'", tostring(key)) ..  "\n" .. debug.traceback()
+		gameanalytics.addErrorEvent {
+			severity = "Error",
+			message = e
+		}
+		log.error(e)
+		return nil		
+	end
+	
+	for i=#patch_data, 1, -1 do
+		
+		local current = patch_data[i].data[key]
+		for j=1,#path do
+			if current == nil then
+				break
+			end
+			current = current[path[j]]
+		end
+		if current ~= nil then
+			return current
+		end
+	end
+	return nil
+end
+
+function M.get_patch_names()
+	local ret = {}
+	for i=1, #patch_data, 1 do
+		table.insert(ret, patch_data[i].name)
+	end
+	return ret
+end
+
+function M.dump_schema_table(schema, indent)
+	local keys_string = ""
+	for j=1,#schema.keys do
+		if keys_string == "" then
+			keys_string = schema.keys[j]
+		else
+			keys_string = keys_string .. ", " .. schema.keys[j]
+		end
+	end
+	print(indent .. "  keys: [" .. keys_string .. "]")
+	if schema.value_type == "array" then
+		print(indent .. "  value_type: array")
+		print(indent .. "  values: ")
+		M.dump_schema_array(schema.values, indent .. "  ")
+	elseif schema.value_type == "table" then
+		print(indent .. "  value_type: table")
+		print(indent .. "  values: ")
+		for k,v in pairs(schema.values) do
+			print(indent .. "- key: " .. k)
+			M.dump_schema_value(v, indent .. "  ")
+		end
+	elseif schema.value_type == "number" then
+		print(indent .. "  value_type: number")
+	else
+		print(indent .. "  value_type: UNKNOWN")
+	end
+end
+
+function M.dump_schema_value(value, indent)
+	if value.type == "table" then
+		print(indent .. "- type: table")
+		M.dump_schema_table(value, indent)
+	elseif value.type == "string" then
+		print(indent .. "- type: string")	
+		print(indent .. "- name: " .. value.name)
+	else		
+		print(indent .. "- type: UNKNOWN")
+	end
+end
+
+function M.dump_schema_array(schema, indent)
+	for i=1,#schema do
+		print(indent .. "[" .. i .. "]")
+		M.dump_schema_value(schema[i], indent .. "  ")
+	end	
+end
+
+function M.dump_schema(schema)
+	M.dump_schema_value(schema, "")
+end
+
+return M

--- a/pokedex/pokedex.lua
+++ b/pokedex/pokedex.lua
@@ -6,6 +6,7 @@ local fakemon = require "fakemon.fakemon"
 local dex_data = require "pokedex.dex_data"
 local ptypes = require "ptypes.main"
 local trainer = require "pokedex.trainer"
+local patch = require "pokedex.patch"
 
 
 local M = {}
@@ -17,6 +18,7 @@ local evolvedata
 local leveldata
 local exp_grid
 local genders
+local patch_key = "Pokedex"
 
 M.GENDERLESS = 0
 M.MALE = 1
@@ -334,6 +336,8 @@ function M.get_pokemon(pokemon)
 		pokemon_species = pokemon_species:gsub("é", "e")
 		local pokemon_json = file.load_json_from_resource("/assets/datafiles/pokemon/".. pokemon_species .. ".json")
 		if pokemon_json ~= nil then
+			local pokemon_patch = patch.get_patch_data(patch_key, {pokemon_species})
+			utils.deep_merge_into(pokemon_json, pokemon_patch)
 			pokedex[pokemon] = pokemon_json
 			return utils.deep_copy(pokedex[pokemon])
 		else

--- a/screens/change_pokemon/change_pokemon.lua
+++ b/screens/change_pokemon/change_pokemon.lua
@@ -274,7 +274,8 @@ local function redraw(self)
 
 	gui.set_text(gui.get_node("change_pokemon/txt_level"), _pokemon.get_current_level(self.pokemon))
 
-	gui.set_text(gui.get_node("change_pokemon/txt_nature"), _pokemon.get_nature(self.pokemon):upper())
+	local patched_nature = natures.get_nature_display(_pokemon.get_nature(self.pokemon))
+	gui.set_text(gui.get_node("change_pokemon/txt_nature"), patched_nature:upper())
 	gui.set_text(gui.get_node("change_pokemon/txt_hit_dice"), "Hit Dice: d" .. _pokemon.get_hit_dice(self.pokemon))
 	gui.set_text(gui.get_node("change_pokemon/pokemon_number"), string.format("#%03d", _pokemon.get_index_number(self.pokemon)))
 	gui.set_text(gui.get_node("change_pokemon/txt_item"), (_pokemon.get_held_item(self.pokemon) or "NO ITEM"):upper())

--- a/screens/change_pokemon/nature/scrollist.gui_script
+++ b/screens/change_pokemon/nature/scrollist.gui_script
@@ -21,7 +21,8 @@ end
 
 local function update_listitem(list, item)
 	gui.set_text(item.nodes["txt_desc"], format_text(item.data))
-	gui.set_text(item.nodes["txt_item"], item.data:upper())
+	local patched_data = natures.get_nature_display(item.data)
+	gui.set_text(item.nodes["txt_item"], patched_data:upper())
 	if item.index == list.selected_item then
 		selected_item = item.data
 	end
@@ -68,7 +69,8 @@ local function filter_list(self, search_string)
 	if #search_string > 0 then
 		self.list_items = {}
 		for i=#self.all_items, 1, -1 do
-			if starts_with(self.all_items[i], search_string) then
+			local patched_item = natures.get_nature_display(self.all_items[i])
+			if starts_with(patched_item, search_string) then
 				table.insert(self.list_items, 1, self.all_items[i])
 			end
 		end

--- a/screens/party/components/information.lua
+++ b/screens/party/components/information.lua
@@ -1,5 +1,6 @@
 local _pokemon = require "pokedex.pokemon"
 local pokedex = require "pokedex.pokedex"
+local natures = require "pokedex.natures"
 local storage = require "pokedex.storage"
 local items = require "pokedex.items"
 local party_utils = require "screens.party.utils"
@@ -98,7 +99,8 @@ local function setup_info_tab(nodes, pokemon)
 	local sr = pokedex.get_pokemon_SR(_pokemon.get_current_species(pokemon))
 	gui.set_text(nodes["pokemon/traits/txt_sr"], number_map[sr] or sr)
 
-	gui.set_text(nodes["pokemon/traits/txt_nature"], _pokemon.get_nature(pokemon):upper())
+	local patched_nature = natures.get_nature_display(_pokemon.get_nature(pokemon))
+	gui.set_text(nodes["pokemon/traits/txt_nature"], patched_nature:upper())
 	gui.set_text(nodes["pokemon/traits/txt_stab"], _pokemon.get_STAB_bonus(pokemon))
 	gui.set_text(nodes["pokemon/traits/txt_prof"], _pokemon.get_proficency_bonus(pokemon))
 	gui.set_text(nodes["pokemon/traits/txt_exp"], _pokemon.get_pokemon_exp_worth(pokemon))

--- a/screens/popups/import/import.gui_script
+++ b/screens/popups/import/import.gui_script
@@ -11,49 +11,47 @@ function init(self)
 
 	self.pokemon = share.get_clipboard()
 
-	local txtNode = gui.get_node("txt")
-	local txtTitleNode = gui.get_node("txt_title")
-	local btnExitNode = gui.get_node("btn_exit")
-	local boxNode = gui.get_node("box")	
-	local btnConfirmNode = gui.get_node("btn_confirm")
+	local node_txt = gui.get_node("txt")
+	local node_txt_title = gui.get_node("txt_title")
+	local node_btn_exit = gui.get_node("btn_exit")
+	local node_box = gui.get_node("box")	
+	local node_btn_confirm = gui.get_node("btn_confirm")
 	
-	local btnConfirmPos = gui.get_position(btnConfirmNode)	
-	local txtMetrics = gui.get_text_metrics_from_node(txtNode)
+	local pos_btn_confirm = gui.get_position(node_btn_confirm)	
+	local metrics_txt = gui.get_text_metrics_from_node(node_txt)
 	
 	if self.pokemon then		
 		local species = _pokemon.get_nickname(self.pokemon) or _pokemon.get_current_species(self.pokemon)
 		local level = _pokemon.get_current_level(self.pokemon)
-		gui.set_text(txtNode, "Do you want to import level " .. level .. " " .. species .. "?")
+		gui.set_text(node_txt, "Do you want to import level " .. level .. " " .. species .. "?")
 	else		
-		gui.set_text(txtTitleNode, "Import Failed")
+		gui.set_text(node_txt_title, "Import Failed")
 		gui.set_text(gui.get_node("txt_confim"), "Ok")		
-		gui.set_text(txtNode, "To import, first copy a Pokemon string to your clipboard.\n\nPokemon strings can be exported from \"Someone's PC\"")
+		gui.set_text(node_txt, "To import, first copy a Pokemon string to your clipboard.\n\nPokemon strings can be exported from \"Someone's PC\"")
 
 		-- Only use 1 button, cancel wouldn't do anything anyway
-		gui.set_enabled(btnExitNode, false)
-		btnConfirmPos.x = 0		
+		gui.set_enabled(node_btn_exit, false)
+		pos_btn_confirm.x = 0		
 	end
 
-	-- Shift everything around to account for the new size of the text node. This would be
-	-- much better done with GUI anchoring / pivots or something, but I couldn't figure out how those worked.
+	-- Shift everything around to account for the new size of the text node
 
-	local newTxtMetrics = gui.get_text_metrics_from_node(txtNode)
-	local txtSizeDiff = newTxtMetrics.height - txtMetrics.height
-	
+	local metrics_txt_new = gui.get_text_metrics_from_node(node_txt)
+	local diff_txt_size = metrics_txt_new.height - metrics_txt.height
 
-	local txtTitlePos = gui.get_position(txtTitleNode)
-	local btnExitPos = gui.get_position(btnExitNode)
-	local boxSize = gui.get_size(boxNode)	
+	local pos_txt_title = gui.get_position(node_txt_title)
+	local pos_btn_exit = gui.get_position(node_btn_exit)
+	local size_box = gui.get_size(node_box)	
 	
-	txtTitlePos.y = txtTitlePos.y + txtSizeDiff/2
-	btnConfirmPos.y = btnConfirmPos.y - txtSizeDiff/2
-	btnExitPos.y = btnExitPos.y - txtSizeDiff/2
-	boxSize.y = boxSize.y + txtSizeDiff
+	pos_txt_title.y = pos_txt_title.y + diff_txt_size/2
+	pos_btn_confirm.y = pos_btn_confirm.y - diff_txt_size/2
+	pos_btn_exit.y = pos_btn_exit.y - diff_txt_size/2
+	size_box.y = size_box.y + diff_txt_size
 	
-	gui.set_position(txtTitleNode, txtTitlePos)
-	gui.set_position(btnConfirmNode, btnConfirmPos)
-	gui.set_position(btnExitNode, btnExitPos)
-	gui.set_size(boxNode, boxSize)
+	gui.set_position(node_txt_title, pos_txt_title)
+	gui.set_position(node_btn_confirm, pos_btn_confirm)
+	gui.set_position(node_btn_exit, pos_btn_exit)
+	gui.set_size(node_box, size_box)
 end
 
 

--- a/screens/popups/import/import.gui_script
+++ b/screens/popups/import/import.gui_script
@@ -10,13 +10,50 @@ function init(self)
 	gui.set_render_order(render_order.POPUP_ON_POPUP)
 
 	self.pokemon = share.get_clipboard()
-	if self.pokemon then
+
+	local txtNode = gui.get_node("txt")
+	local txtTitleNode = gui.get_node("txt_title")
+	local btnExitNode = gui.get_node("btn_exit")
+	local boxNode = gui.get_node("box")	
+	local btnConfirmNode = gui.get_node("btn_confirm")
+	
+	local btnConfirmPos = gui.get_position(btnConfirmNode)	
+	local txtMetrics = gui.get_text_metrics_from_node(txtNode)
+	
+	if self.pokemon then		
 		local species = _pokemon.get_nickname(self.pokemon) or _pokemon.get_current_species(self.pokemon)
-		gui.set_text(gui.get_node("txt"), "Do you want to import " .. species .. "?")
-	else
-		gui.set_text(gui.get_node("txt_confim"), "Ok")
-		gui.set_text(gui.get_node("txt"), "Could not import the pokemon")
+		local level = _pokemon.get_current_level(self.pokemon)
+		gui.set_text(txtNode, "Do you want to import level " .. level .. " " .. species .. "?")
+	else		
+		gui.set_text(txtTitleNode, "Import Failed")
+		gui.set_text(gui.get_node("txt_confim"), "Ok")		
+		gui.set_text(txtNode, "To import, first copy a Pokemon string to your clipboard.\n\nPokemon strings can be exported from \"Someone's PC\"")
+
+		-- Only use 1 button, cancel wouldn't do anything anyway
+		gui.set_enabled(btnExitNode, false)
+		btnConfirmPos.x = 0		
 	end
+
+	-- Shift everything around to account for the new size of the text node. This would be
+	-- much better done with GUI anchoring / pivots or something, but I couldn't figure out how those worked.
+
+	local newTxtMetrics = gui.get_text_metrics_from_node(txtNode)
+	local txtSizeDiff = newTxtMetrics.height - txtMetrics.height
+	
+
+	local txtTitlePos = gui.get_position(txtTitleNode)
+	local btnExitPos = gui.get_position(btnExitNode)
+	local boxSize = gui.get_size(boxNode)	
+	
+	txtTitlePos.y = txtTitlePos.y + txtSizeDiff/2
+	btnConfirmPos.y = btnConfirmPos.y - txtSizeDiff/2
+	btnExitPos.y = btnExitPos.y - txtSizeDiff/2
+	boxSize.y = boxSize.y + txtSizeDiff
+	
+	gui.set_position(txtTitleNode, txtTitlePos)
+	gui.set_position(btnConfirmNode, btnConfirmPos)
+	gui.set_position(btnExitNode, btnExitPos)
+	gui.set_size(boxNode, boxSize)
 end
 
 

--- a/screens/popups/patch/patch.collection
+++ b/screens/popups/patch/patch.collection
@@ -1,0 +1,37 @@
+name: "are_you_sure"
+scale_along_z: 0
+embedded_instances {
+  id: "go"
+  data: "components {\n"
+  "  id: \"gui\"\n"
+  "  component: \"/screens/popups/patch/patch.gui\"\n"
+  "  position {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/screens/popups/patch/patch.gui
+++ b/screens/popups/patch/patch.gui
@@ -1,11 +1,15 @@
-script: "/screens/settings/settings.gui_script"
+script: "/screens/popups/patch/patch.gui_script"
 fonts {
-  name: "title"
-  font: "/assets/fonts/title.font"
+  name: "script_bold"
+  font: "/assets/fonts/script_bold.font"
 }
 fonts {
   name: "script"
   font: "/assets/fonts/script.font"
+}
+fonts {
+  name: "title"
+  font: "/assets/fonts/title.font"
 }
 textures {
   name: "gui"
@@ -19,8 +23,117 @@ background_color {
 }
 nodes {
   position {
+    x: 360.0
+    y: 640.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
     x: 0.0
     y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.9411765
+    y: 0.9411765
+    z: 0.9411765
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/square"
+  id: "root"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_SW
+  adjust_mode: ADJUST_MODE_STRETCH
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 2.0
+    y: 2.0
+    z: 2.0
+    w: 2.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 720.0
+    y: 1280.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.9411765
+    y: 0.9411765
+    z: 0.9411765
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/square"
+  id: "box"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_STRETCH
+  parent: "root"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: -360.0
+    y: -640.0
     z: 0.0
     w: 1.0
   }
@@ -49,7 +162,8 @@ nodes {
     w: 1.0
   }
   type: TYPE_TEMPLATE
-  id: "top_divider"
+  id: "topbar"
+  parent: "root"
   layer: ""
   inherit_alpha: true
   alpha: 1.0
@@ -90,12 +204,12 @@ nodes {
   type: TYPE_BOX
   blend_mode: BLEND_MODE_ALPHA
   texture: "gui/shadow"
-  id: "top_divider/shadow"
+  id: "topbar/shadow"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
   pivot: PIVOT_CENTER
   adjust_mode: ADJUST_MODE_STRETCH
-  parent: "top_divider"
+  parent: "topbar"
   layer: "gui"
   inherit_alpha: true
   slice9 {
@@ -145,12 +259,12 @@ nodes {
   type: TYPE_BOX
   blend_mode: BLEND_MODE_ALPHA
   texture: "gui/title_backing"
-  id: "top_divider/box"
+  id: "topbar/box"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
   pivot: PIVOT_CENTER
   adjust_mode: ADJUST_MODE_STRETCH
-  parent: "top_divider"
+  parent: "topbar"
   layer: "gui"
   inherit_alpha: true
   slice9 {
@@ -199,9 +313,9 @@ nodes {
   }
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
-  text: "Settings"
+  text: "Patches"
   font: "title"
-  id: "top_divider/title"
+  id: "topbar/title"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_TOP
   pivot: PIVOT_W
@@ -219,7 +333,7 @@ nodes {
   }
   adjust_mode: ADJUST_MODE_FIT
   line_break: false
-  parent: "top_divider/box"
+  parent: "topbar/box"
   layer: "title"
   inherit_alpha: true
   alpha: 1.0
@@ -232,8 +346,8 @@ nodes {
 }
 nodes {
   position {
-    x: 360.0
-    y: 640.0
+    x: 0.0
+    y: 444.0
     z: 0.0
     w: 1.0
   }
@@ -250,89 +364,35 @@ nodes {
     w: 1.0
   }
   size {
-    x: 0.0
-    y: 0.0
+    x: 660.0
+    y: 1000.0
     z: 0.0
     w: 1.0
   }
   color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: ""
-  id: "root"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_STRETCH
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 0.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
-}
-nodes {
-  position {
-    x: 0.0
-    y: 448.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 710.0
-    y: 200.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 0.8
-    y: 0.8
-    z: 0.8
+    x: 0.9411765
+    y: 0.9411765
+    z: 0.9411765
     w: 1.0
   }
   type: TYPE_BOX
   blend_mode: BLEND_MODE_ALPHA
   texture: "gui/details_backing"
-  id: "fakemon"
+  id: "scroll_area"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_TOP
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
+  pivot: PIVOT_N
+  adjust_mode: ADJUST_MODE_STRETCH
   parent: "root"
-  layer: "gui"
-  inherit_alpha: false
+  layer: ""
+  inherit_alpha: true
   slice9 {
     x: 8.0
     y: 8.0
     z: 8.0
     w: 8.0
   }
-  clipping_mode: CLIPPING_MODE_NONE
+  clipping_mode: CLIPPING_MODE_STENCIL
   clipping_visible: true
   clipping_inverted: false
   alpha: 1.0
@@ -341,134 +401,8 @@ nodes {
 }
 nodes {
   position {
-    x: -352.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
     x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.5
-    y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 50.0
-    y: 45.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 0.24313726
-    y: 0.24313726
-    z: 0.24313726
-    w: 1.0
-  }
-  type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "FAKEMON"
-  font: "script"
-  id: "title_fakemon"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_NW
-  outline {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
-  parent: "fakemon"
-  layer: "script"
-  inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 0.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
-}
-nodes {
-  position {
-    x: -350.0
-    y: 35.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 0.6
-    y: 0.6
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 900.0
-    y: 60.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 0.14901961
-    y: 0.14117648
-    z: 0.1254902
-    w: 1.0
-  }
-  type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "Add a package of Fakemon to your app."
-  font: "script"
-  id: "desc_fakemon"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_NW
-  outline {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: true
-  parent: "fakemon"
-  layer: "script"
-  inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 0.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
-}
-nodes {
-  position {
-    x: 249.0
-    y: -49.0
+    y: -6.0
     z: 0.0
     w: 1.0
   }
@@ -485,8 +419,8 @@ nodes {
     w: 1.0
   }
   size {
-    x: 200.0
-    y: 60.0
+    x: 600.0
+    y: 165.0
     z: 0.0
     w: 1.0
   }
@@ -498,20 +432,20 @@ nodes {
   }
   type: TYPE_BOX
   blend_mode: BLEND_MODE_ALPHA
-  texture: "gui/common_up"
-  id: "btn_pick_fakemon"
+  texture: "gui/add_backing"
+  id: "btn_item"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
+  pivot: PIVOT_N
   adjust_mode: ADJUST_MODE_FIT
-  parent: "fakemon"
-  layer: ""
-  inherit_alpha: true
+  parent: "scroll_area"
+  layer: "gui"
+  inherit_alpha: false
   slice9 {
-    x: 8.0
-    y: 8.0
-    z: 8.0
-    w: 8.0
+    x: 15.0
+    y: 15.0
+    z: 15.0
+    w: 30.0
   }
   clipping_mode: CLIPPING_MODE_NONE
   clipping_visible: true
@@ -522,8 +456,8 @@ nodes {
 }
 nodes {
   position {
-    x: 0.0
-    y: 0.0
+    x: -283.0
+    y: -21.0
     z: 0.0
     w: 1.0
   }
@@ -540,207 +474,26 @@ nodes {
     w: 1.0
   }
   size {
-    x: 100.0
-    y: 45.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "PICK"
-  font: "script"
-  id: "txt_paste"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
-  parent: "btn_pick_fakemon"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 1.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
-}
-nodes {
-  position {
-    x: -350.0
-    y: -28.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 450.0
+    x: 350.0
     y: 40.0
     z: 0.0
     w: 1.0
   }
   color {
-    x: 0.14901961
-    y: 0.14117648
-    z: 0.1254902
+    x: 0.0
+    y: 0.0
+    z: 0.0
     w: 1.0
   }
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
-  text: "\n"
+  text: "Patch Name\n"
   ""
   font: "script"
-  id: "name_fakemon"
+  id: "txt_title"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
-  pivot: PIVOT_NW
-  outline {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: true
-  parent: "fakemon"
-  layer: "script"
-  inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 0.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
-}
-nodes {
-  position {
-    x: 249.0
-    y: 60.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 60.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "gui/common_up"
-  id: "btn_remove_fakemon"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  parent: "fakemon"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 8.0
-    y: 8.0
-    z: 8.0
-    w: 8.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
-}
-nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 100.0
-    y: 45.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "REMOVE"
-  font: "script"
-  id: "txt_remove"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
+  pivot: PIVOT_W
   outline {
     x: 1.0
     y: 1.0
@@ -755,8 +508,8 @@ nodes {
   }
   adjust_mode: ADJUST_MODE_FIT
   line_break: false
-  parent: "btn_remove_fakemon"
-  layer: ""
+  parent: "btn_item"
+  layer: "script"
   inherit_alpha: true
   alpha: 1.0
   outline_alpha: 1.0
@@ -767,8 +520,8 @@ nodes {
 }
 nodes {
   position {
-    x: 0.0
-    y: 277.0
+    x: -279.0
+    y: -41.0
     z: 0.0
     w: 1.0
   }
@@ -779,146 +532,28 @@ nodes {
     w: 1.0
   }
   scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 710.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
     x: 0.8
     y: 0.8
-    z: 0.8
-    w: 1.0
-  }
-  type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "gui/details_backing"
-  id: "patch"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_TOP
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  parent: "root"
-  layer: "gui"
-  inherit_alpha: false
-  slice9 {
-    x: 8.0
-    y: 8.0
-    z: 8.0
-    w: 8.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
-}
-nodes {
-  position {
-    x: -352.0
-    y: 50.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.5
-    y: 1.5
     z: 1.0
     w: 1.0
   }
   size {
-    x: 50.0
-    y: 45.0
+    x: 680.0
+    y: 105.0
     z: 0.0
     w: 1.0
   }
   color {
-    x: 0.24313726
-    y: 0.24313726
-    z: 0.24313726
+    x: 0.2
+    y: 0.2
+    z: 0.2
     w: 1.0
   }
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
-  text: "Patches"
+  text: "Description goes here"
   font: "script"
-  id: "title_patch"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_NW
-  outline {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
-  parent: "patch"
-  layer: "script"
-  inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 0.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
-}
-nodes {
-  position {
-    x: -350.0
-    y: -15.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 0.6
-    y: 0.6
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 900.0
-    y: 60.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 0.14901961
-    y: 0.14117648
-    z: 0.1254902
-    w: 1.0
-  }
-  type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "Download patches to adjust data used by you app."
-  font: "script"
-  id: "desc_patches"
+  id: "txt_description"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
   pivot: PIVOT_NW
@@ -936,11 +571,11 @@ nodes {
   }
   adjust_mode: ADJUST_MODE_FIT
   line_break: true
-  parent: "patch"
+  parent: "btn_item"
   layer: "script"
   inherit_alpha: true
   alpha: 1.0
-  outline_alpha: 0.0
+  outline_alpha: 1.0
   shadow_alpha: 1.0
   template_node_child: false
   text_leading: 1.0
@@ -948,8 +583,8 @@ nodes {
 }
 nodes {
   position {
-    x: 249.0
-    y: 0.0
+    x: 282.0
+    y: -18.0
     z: 0.0
     w: 1.0
   }
@@ -960,86 +595,31 @@ nodes {
     w: 1.0
   }
   scale {
-    x: 1.0
-    y: 1.0
+    x: 0.7
+    y: 0.7
     z: 1.0
     w: 1.0
   }
   size {
-    x: 200.0
-    y: 60.0
+    x: 300.0
+    y: 40.0
     z: 0.0
     w: 1.0
   }
   color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "gui/common_up"
-  id: "btn_choose_patches"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  parent: "patch"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 8.0
-    y: 8.0
-    z: 8.0
-    w: 8.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
-  template_node_child: false
-  size_mode: SIZE_MODE_MANUAL
-}
-nodes {
-  position {
     x: 0.0
     y: 0.0
     z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 100.0
-    y: 45.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
     w: 1.0
   }
   type: TYPE_TEXT
   blend_mode: BLEND_MODE_ALPHA
-  text: "CHOOSE"
+  text: "by. Author Name"
   font: "script"
-  id: "txt_go_patches"
+  id: "txt_author"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
+  pivot: PIVOT_E
   outline {
     x: 1.0
     y: 1.0
@@ -1054,8 +634,71 @@ nodes {
   }
   adjust_mode: ADJUST_MODE_FIT
   line_break: false
-  parent: "btn_choose_patches"
-  layer: ""
+  parent: "btn_item"
+  layer: "script"
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: false
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 285.0
+    y: -141.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 0.5
+    y: 0.5
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 520.0
+    y: 40.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.5019608
+    y: 0.5019608
+    z: 0.5019608
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Last update: 6/26/2020 1:05 PM"
+  font: "script"
+  id: "txt_last_update"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_E
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "btn_item"
+  layer: "script"
   inherit_alpha: true
   alpha: 1.0
   outline_alpha: 1.0
@@ -1067,7 +710,7 @@ nodes {
 nodes {
   position {
     x: -310.0
-    y: 604.0
+    y: 605.0
     z: 0.0
     w: 1.0
   }
@@ -1098,7 +741,7 @@ nodes {
   type: TYPE_BOX
   blend_mode: BLEND_MODE_ALPHA
   texture: "gui/close_up"
-  id: "btn_close"
+  id: "btn_quit"
   xanchor: XANCHOR_NONE
   yanchor: YANCHOR_TOP
   pivot: PIVOT_CENTER
@@ -1119,14 +762,450 @@ nodes {
   template_node_child: false
   size_mode: SIZE_MODE_MANUAL
 }
+nodes {
+  position {
+    x: 0.0
+    y: 491.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 600.0
+    y: 80.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/add_backing"
+  id: "bg"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_TOP
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "root"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 15.0
+    y: 15.0
+    z: 15.0
+    w: 30.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 8.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/background_gradient"
+  id: "zero"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "bg"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 400.0
+    y: 40.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "SEARCH"
+  font: "script"
+  id: "search_text"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "zero"
+  layer: "script"
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 1.0
+  shadow_alpha: 1.0
+  template_node_child: false
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: -50.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 2.0
+    y: 40.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/square"
+  id: "cursor"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "zero"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 346.0
+    y: -556.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "scrollbar"
+  parent: "root"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/templates/scrollbar.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 20.0
+    y: 1000.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/scroll_bar"
+  id: "scrollbar/bar"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_S
+  adjust_mode: ADJUST_MODE_STRETCH
+  parent: "scrollbar"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 15.0
+    z: 0.0
+    w: 15.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 952.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 50.0
+    y: 96.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/transparent"
+  id: "scrollbar/handle"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "scrollbar/bar"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 0.91
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 15.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.8
+    y: 0.8
+    z: 0.8
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/scroll_bar"
+  id: "scrollbar/visual"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "scrollbar/handle"
+  layer: "gui"
+  inherit_alpha: false
+  slice9 {
+    x: 0.0
+    y: 15.0
+    z: 0.0
+    w: 15.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
 layers {
   name: "gui"
 }
 layers {
-  name: "title"
+  name: "script"
 }
 layers {
-  name: "script"
+  name: "script_bold"
+}
+layers {
+  name: "title"
 }
 material: "/builtins/materials/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT

--- a/screens/popups/patch/patch.gui_script
+++ b/screens/popups/patch/patch.gui_script
@@ -1,0 +1,139 @@
+local monarch  = require "monarch.monarch"
+local url = require "utils.url"
+local render_order = require "utils.gui_render_order"
+local gooey_buttons = require "utils.gooey_buttons"
+local gooey = require "gooey.gooey"
+local utils = require "utils.utils"
+local gui_utils = require "utils.gui"
+local patch = require "pokedex.patch"
+local flow = require "utils.flow"
+
+local selected_item
+local all_item_details = {}
+
+local function close()
+	monarch.back()
+end
+
+local function update_listitem(list, item)
+	local data = all_item_details[item.data]
+	
+	gui.set_text(item.nodes["txt_title"], tostring(data.name) or "<Unknown Patch>")
+	gui.set_text(item.nodes["txt_description"], tostring(data.description) or "")
+	
+	local author_text = ""
+	if data.author ~= nil then
+		author_text = "by: " .. tostring(data.author)
+	end
+	gui.set_text(item.nodes["txt_author"], author_text)
+
+	local download_datetime_text = ""
+	if data.last_download_success ~= nil and type(data.last_download_success) == "number" then
+		download_datetime_text = "Last update: " .. os.date("%c", data.last_download_success)
+	end
+	gui.set_text(item.nodes["txt_last_update"], download_datetime_text)
+	
+	if item.index == list.selected_item then
+		selected_item = item.data
+	end
+end
+
+local function update_list(list)
+	gooey.vertical_scrollbar("scrollbar/handle", "scrollbar/bar").scroll_to(0, list.scroll.y)
+	for i,item in ipairs(list.items) do
+		if item.data and item.data ~= "" then
+			update_listitem(list, item)
+		end
+	end
+end
+
+local function on_item_selected(list)
+	for i,item in ipairs(list.items) do
+		if item.data and item.index == list.selected_item then
+			print("TODO item " .. tostring(item.index) .. " selected")
+		end
+	end
+end
+
+function init(self)
+	msg.post(url.MENU, "hide")
+	gui.set_enabled(gui.get_node("cursor"), false)
+
+	all_item_details = {}
+	self.all_items = {}
+	self.list_items = {}
+	update_list(gooey.dynamic_list("scrollist", "scroll_area", "btn_item", self.all_items))
+	
+	flow.start(function()
+		all_item_details = patch.get_all_patch_data_details()
+
+		if all_item_details ~= nil then
+			for index, _ in pairs(all_item_details) do
+				table.insert(self.all_items, index)
+			end
+			self.list_items = utils.shallow_copy(self.all_items)
+		
+			update_list(gooey.dynamic_list("scrollist", "scroll_area", "btn_item", self.list_items))
+		end
+	end)
+end
+
+local function filter_list(self, search_string)
+	local function starts_with(str, start)
+		return string.lower(str):sub(1, #start) == string.lower(start)
+	end
+	local function is_in(_in, str)
+		return string.lower(_in):find(string.lower(str))
+	end
+	if #search_string > 0 then
+		self.list_items = {}
+		for i=#self.all_items, 1, -1 do
+			if starts_with(all_item_details[self.all_items[i]].name, search_string) then
+				table.insert(self.list_items, 1, self.all_items[i])
+			end
+		end
+		update_list(gooey.dynamic_list("scrollist", "scroll_area", "btn_item", self.list_items))
+	else
+		self.list_items = self.all_items
+	end
+end
+
+local function refresh_input(self, input, node_id)
+	if input.empty and not input.selected then
+		gui.set_text(input.node, "SEARCH")
+	end
+
+	local cursor = gui.get_node("cursor")
+	if input.selected then
+		if input.empty then
+			gui.set_text(input.node, "")
+		end
+		gui.set_enabled(cursor, true)
+		gui.set_position(cursor, vmath.vector3(input.total_width*0.5, 0, 0))
+		gui.cancel_animation(cursor, gui.PROP_COLOR)
+		gui.set_color(cursor, vmath.vector4(0,0,0,1))
+		gui.animate(cursor, gui.PROP_COLOR, vmath.vector4(1,1,1,0), gui.EASING_INSINE, 0.8, 0, nil, gui.PLAYBACK_LOOP_PINGPONG)
+	else
+		gui.set_enabled(cursor, false)
+		gui.cancel_animation(cursor, gui.PROP_COLOR)
+	end
+	filter_list(self, input.text .. input.marked_text)
+end
+
+local function on_scrolled(self, scrollbar)
+	gooey.dynamic_list("scrollist", "scroll_area", "btn_item", self.list_items).scroll_to(0, scrollbar.scroll.y)
+end
+
+
+function on_input(self, action_id, action)
+	if next(self.list_items) ~= nil then
+		local list = gooey.dynamic_list("scrollist", "scroll_area", "btn_item", self.list_items, action_id, action, on_item_selected, update_list)
+		if list.max_y and list.max_y > 0 then
+			gooey.vertical_scrollbar("scrollbar/handle", "scrollbar/bar", action_id, action, function(scrollbar) on_scrolled(self, scrollbar) end)
+		end
+	end
+	gooey.input("search_text", gui.KEYBOARD_TYPE_DEFAULT, action_id, action, {use_marked_text=false}, function(input)
+		refresh_input(self, input, "search_text")
+	end)
+	gooey.button("btn_quit", action_id, action, close, gooey_buttons.close_button)
+end

--- a/screens/settings/settings.gui_script
+++ b/screens/settings/settings.gui_script
@@ -44,4 +44,8 @@ function on_input(self, action_id, action)
 			msg.post("@system:", "reboot")
 		end)
 	end, function(button) gooey_buttons.common_button(button, gui.get_node("txt_paste")) end)
+	
+	gooey.button("btn_choose_patches", action_id, action, function()
+		monarch.show("patch")
+	end, function(button) gooey_buttons.common_button(button, gui.get_node("txt_paste")) end)
 end

--- a/utils/tracking_id.lua
+++ b/utils/tracking_id.lua
@@ -31,6 +31,7 @@ local M = {
 	[hash("pokedex")] = 222,
 	[hash("settings")] = 223,
 	[hash("fakemon")] = 224,
+	[hash("patch")] = 225,
 }
 
 return M

--- a/utils/utils.lua
+++ b/utils/utils.lua
@@ -57,6 +57,35 @@ function M.merge(T1, T2)
 	return copy
 end
 
+local function deep_merge_into_recurse(target, copy_from)
+	for k_copy_from, v_copy_from in pairs(copy_from) do
+		local v_target = target[k_copy_from]
+		if v_target ~= nil then
+			-- Value existed before, verify types match and then replace it
+			if type(v_target) == type(v_copy_from) then
+				if type(v_target) == 'table' then
+					deep_merge_into_recurse(v_target, v_copy_from)
+				else
+					target[k_copy_from] = v_copy_from
+				end
+			end
+		else
+			-- Value didn't exist before, add it
+			if type(v_copy_from) == 'table' then	
+				target[k_copy_from] = M.deep_copy(v_copy_from)
+			else
+				target[k_copy_from] = v_copy_from
+			end
+		end
+	end	
+end
+
+function M.deep_merge_into(target, copy_from)
+	if target ~= nil and copy_from ~= nil and type(target) == 'table' and type(copy_from) == 'table' then
+		deep_merge_into_recurse(target, copy_from)
+	end
+end
+
 function M.split(str, sep)
 	if sep == nil then
 		sep = "%s"


### PR DESCRIPTION
This is in response to Varnell who wants to modify certain aspects of the game without needing to edit the app itself.

I came up with the concept of data patching. You can download (by some fashion) patch file(s). These get applied in order, with later patches taking precedence. Systems can talk to the patch system and go through it when retrieving values to have those values be patched.

Proof-of-concept here swaps offensive term "Dumb" with "Quiet" instead. The data is still "Dumb" behind the scenes, but when displayed the value is changed to "Quiet".

In theory this could be expanded to:

- More systems using it (like moves - Varnell notably wanted to change move speed per species)
- Ability to share/download patches in some way
- Ability to enable/disable patches, like via a new screen listing the patches and enable/disable checkboxes
- Global event when patches change so systems can cache values. Right now the nature lookup hits the patch system every time; that could be cached instead. Plus, the natures list sorted according to their original data names - the sorting could also be updated when patches change.

One thing I believe I would NOT want to do is create a UI to actually generate the data. Instead, I feel it would be a lot less work (and a lot better user experience) to publish the patch data API and have users generate their own data (say via json), then tell the app to download patches - either by pasting from the clipboard like with importing pokemon, or (more likely?) downloading from a url.