### PR TITLE
Fixed the move Curse to not show an attack bonus

### DIFF
--- a/assets/datafiles/moves.json
+++ b/assets/datafiles/moves.json
@@ -2720,7 +2720,7 @@
         "move": false
       }
     },
-    "ab": true,
+    "ab": false,
     "stab": true
   },
   "Cut": {


### PR DESCRIPTION
Fixes #419 (Bug: Curse should not show an attack bonus)