### PR TITLE
Fixed several guaranteed to hit moves which were not using STAB

### DIFF
--- a/assets/datafiles/moves.json
+++ b/assets/datafiles/moves.json
@@ -255,7 +255,7 @@
         "move": true
       }
     },
-    "stab": false
+    "stab": true
   },
   "Aeroblast": {
     "Type": "Flying",
@@ -743,7 +743,7 @@
         "move": true
       }
     },
-    "stab": false
+    "stab": true
   },
   "Aurora Beam": {
     "Type": "Ice",
@@ -7337,7 +7337,7 @@
     "Range": "60ft",
     "Description": "Using your many arms, you send a barrage of three balls of furious energy at any creature(s) in range. Each ball automatically deals 1d6 dark damage to any creature(s) you choose. Reactions that negate damage such as Protect or Detect cannot be used. After activating this move, any attacks against you, until the beginning of your next turn, are rolled at advantage.",
     "ab": false,
-    "stab": false
+    "stab": true
   },
   "Hyperspace Hole": {
     "Type": "Psychic",
@@ -8756,7 +8756,7 @@
       }
     },
     "ab": false,
-    "stab": false
+    "stab": true
   },
   "Magma Storm": {
     "Type": "Fire",
@@ -13126,7 +13126,7 @@
       }
     },
     "ab": false,
-    "stab": false
+    "stab": true
   },
   "Shadow Sneak": {
     "Type": "Ghost",
@@ -13258,7 +13258,7 @@
       }
     },
     "ab": false,
-    "stab": false
+    "stab": true
   },
   "Signal Beam": {
     "Type": "Bug",
@@ -13831,7 +13831,7 @@
       }
     },
     "ab": false,
-    "stab": false
+    "stab": true
   },
   "Smelling Salts": {
     "Type": "Normal",


### PR DESCRIPTION
Fixes #421 (Bug: Several "guaranteed to hit" moves don't properly use STAB)