### PR TITLE
Fixing "Change Max HP" functionality

### DIFF
--- a/screens/change_pokemon/change_pokemon.lua
+++ b/screens/change_pokemon/change_pokemon.lua
@@ -693,7 +693,7 @@ function M.on_input(self, action_id, action)
 			_pokemon.set_max_hp(self.pokemon, _pokemon.get_max_hp(self.pokemon) - 1)
 			M.update_hp_counter(self)
 		else
-			monarch.show(screens.ARE_YOU_SURE, nil, {title="Are you sure?", text="You will have to track it manually henceforth", sender=msg.url(), data=-1, id="change_hp"})
+			monarch.show(screens.ARE_YOU_SURE, nil, {title="Are you sure?", text="You will have to track it manually henceforth", sender=msg.url(), data=-1, id=messages.CHANGE_HP})
 		end
 	end, gooey_buttons.minus_button)
 
@@ -707,7 +707,7 @@ function M.on_input(self, action_id, action)
 			_pokemon.set_max_hp(self.pokemon, _pokemon.get_max_hp(self.pokemon) + 1)
 			M.update_hp_counter(self)
 		else
-			monarch.show(screens.ARE_YOU_SURE, nil, {title="Are you sure?", text="You will have to track it manually henceforth", sender=msg.url(), data=1, id="change_hp"})
+			monarch.show(screens.ARE_YOU_SURE, nil, {title="Are you sure?", text="You will have to track it manually henceforth", sender=msg.url(), data=1, id=messages.CHANGE_HP})
 		end
 	end, gooey_buttons.plus_button)
 	

--- a/screens/change_pokemon/edit/edit.gui_script
+++ b/screens/change_pokemon/edit/edit.gui_script
@@ -86,7 +86,7 @@ function init(self)
 	end
 
 	button.register("change_pokemon/txt_max_hp", function()
-		monarch.show(screens.ARE_YOU_SURE, nil, {sender=msg.url(), text="Reset HP and let the App controll it for you", title="Reset", id="reset"})
+		monarch.show(screens.ARE_YOU_SURE, nil, {sender=msg.url(), text="Reset HP and let the App controll it for you", title="Reset", id=messages.RESET})
 	end)
 end
 


### PR DESCRIPTION
Fixes #513.

Also note I found some other, similar IDs that were not using the new `messages` constants. However, they didn't appear to be broken - for example, evolving. I didn't want to mess with them because they were not broken.