### PR TITLE
Only accept ipv4 as a local address

### DIFF
--- a/pokedex/network/net_ip.lua
+++ b/pokedex/network/net_ip.lua
@@ -33,7 +33,7 @@ function M.refresh_local_ip()
 		local local_ip_info = sys.get_ifaddrs()
 		for i=1,#local_ip_info do
 			local t = local_ip_info[i]
-			if t.running and t.up then
+			if t.running and t.up and t.family == "ipv4" then
 				found_ip = t.address
 				break
 			end


### PR DESCRIPTION
The error was because there is a lot of entries in the table that are running and up, some are ipv6 addresses which happens to come before in the table. We should only accept ipv4 addresses.

I have confirmed that I can connect to a iPhone over a local network with the iPhone as a host with this fix.