### PR TITLE
Always clear out the current profile when deleting any profile. This …

### DIFF
--- a/pokedex/profiles.lua
+++ b/pokedex/profiles.lua
@@ -73,8 +73,9 @@ function M.update(slot, data)
 end
 
 function M.delete(slot)
-	if slot == M.get_active_slot() then
+	if M.get_active_slot() then
 		M.set_active(nil)
+		M.set_active_complete()
 	end
 	
 	local f_name = M.get_file_name(slot)

--- a/screens/profiles/profiles.gui_script
+++ b/screens/profiles/profiles.gui_script
@@ -92,10 +92,6 @@ end
 
 
 local function delete_profile(self, slot)
-	if profiles.get_active_slot() == slot then
-		profiles.set_active(nil)
-		profiles.set_active_complete()
-	end
 	profiles.delete(slot)
 	gui.set_text(self.seach_text, "")
 	self.scrolling_data = {}


### PR DESCRIPTION
…isn't ideal, but it's a quick way to fix a bug with indices getting out of whack - indices are based on the array of profiles, so when one BEFORE the current active profile gets deleted, the current active profile index is actually invalid. There are a number of ways this could be cleaned up - such as by not tracking the slot index - but that's more work than this quick fix. And in any case, the only place you can currently delete proifles is the profile selection screen anyway, so you still have to select a profile after deleting one, and it doesn't matter much than one is no longer active.

Should fix #548; however, I wasn't able to reproduce before or after this change, so may need more testing.