### PR TITLE
Pokemon now support "variants" which can be chosen at Pokemon creatio…

### DIFF
--- a/assets/datafiles/pokemon/Gourgeist.json
+++ b/assets/datafiles/pokemon/Gourgeist.json
@@ -96,7 +96,8 @@
           "CON": 18,
           "DEX": 13
         }
-      }
+      },
+      "Display": "Gourgeist (Average)"
     },
     "Large": {
       "Default": false,
@@ -105,10 +106,12 @@
           "CON": 19,
           "DEX": 12
         }
-      }
+      },
+      "Display": "Gourgeist (Large)"
     },
     "Small": {
-      "Default": true
+      "Default": true,
+      "Display": "Gourgeist (Small)"
     },
     "Supersize": {
       "Default": false,
@@ -117,7 +120,8 @@
           "CON": 20,
           "DEX": 11
         }
-      }
+      },
+      "Display": "Gourgeist (Supersize)"
     }
   },
   "WSp": 25,

--- a/assets/datafiles/pokemon/Gourgeist.json
+++ b/assets/datafiles/pokemon/Gourgeist.json
@@ -88,6 +88,38 @@
     "Ghost",
     "Grass"
   ],
+  "Variants": {
+    "Average": {
+      "Default": false,
+      "Diff": {
+        "attributes": {
+          "CON": 18,
+          "DEX": 13
+        }
+      }
+    },
+    "Large": {
+      "Default": false,
+      "Diff": {
+        "attributes": {
+          "CON": 19,
+          "DEX": 12
+        }
+      }
+    },
+    "Small": {
+      "Default": true
+    },
+    "Supersize": {
+      "Default": false,
+      "Diff": {
+        "attributes": {
+          "CON": 20,
+          "DEX": 11
+        }
+      }
+    }
+  },
   "WSp": 25,
   "attributes": {
     "CHA": 10,

--- a/assets/datafiles/pokemon/Pumpkaboo.json
+++ b/assets/datafiles/pokemon/Pumpkaboo.json
@@ -96,7 +96,8 @@
           "CON": 14,
           "DEX": 13
         }
-      }
+      },
+      "Display": "Pumpkaboo (Average)"
     },
     "Large": {
       "Default": false,
@@ -105,10 +106,12 @@
           "CON": 15,
           "DEX": 12
         }
-      }
+      },
+      "Display": "Pumpkaboo (Large)"
     },
     "Small": {
-      "Default": true
+      "Default": true,
+      "Display": "Pumpkaboo (Small)"
     },
     "Supersize": {
       "Default": false,
@@ -117,7 +120,8 @@
           "CON": 16,
           "DEX": 11
         }
-      }
+      },
+      "Display": "Pumpkaboo (Supersize)"
     }
   },
   "WSp": 20,

--- a/assets/datafiles/pokemon/Pumpkaboo.json
+++ b/assets/datafiles/pokemon/Pumpkaboo.json
@@ -88,6 +88,38 @@
     "Ghost",
     "Grass"
   ],
+  "Variants": {
+    "Average": {
+      "Default": false,
+      "Diff": {
+        "attributes": {
+          "CON": 14,
+          "DEX": 13
+        }
+      }
+    },
+    "Large": {
+      "Default": false,
+      "Diff": {
+        "attributes": {
+          "CON": 15,
+          "DEX": 12
+        }
+      }
+    },
+    "Small": {
+      "Default": true
+    },
+    "Supersize": {
+      "Default": false,
+      "Diff": {
+        "attributes": {
+          "CON": 16,
+          "DEX": 11
+        }
+      }
+    }
+  },
   "WSp": 20,
   "attributes": {
     "CHA": 10,

--- a/pokedex/pokedex.lua
+++ b/pokedex/pokedex.lua
@@ -193,6 +193,19 @@ function M.get_variants(pokemon)
 end
 
 
+function M.get_default_variant(pokemon)
+	local raw = M.get_pokemon_raw(pokemon)
+	if raw.Variants then
+		for k,v in pairs(raw.Variants) do
+			if v.Default then
+				return k
+			end
+		end
+	end
+	return nil
+end
+
+
 function M.get_species_display(pokemon, variant)
 	if variant then
 		local raw = M.get_pokemon_raw(pokemon)

--- a/pokedex/pokedex.lua
+++ b/pokedex/pokedex.lua
@@ -193,6 +193,20 @@ function M.get_variants(pokemon)
 end
 
 
+function M.get_species_display(pokemon, variant)
+	if variant then
+		local raw = M.get_pokemon_raw(pokemon)
+		if raw.Variants then
+			var_data = raw.Variants[variant]
+			if var_data and var_data.Display then
+				return var_data.Display
+			end
+		end
+	end
+	return pokemon
+end
+
+
 function M.get_icon(pokemon, variant)
 	local data = M.get_pokemon(pokemon, variant)
 	local sprite = M.get_sprite(pokemon)

--- a/pokedex/pokedex.lua
+++ b/pokedex/pokedex.lua
@@ -11,6 +11,7 @@ local trainer = require "pokedex.trainer"
 local M = {}
 
 local pokedex
+local pokedex_variants
 local pokedex_extra
 local abilities = {}
 local evolvedata
@@ -79,6 +80,7 @@ end
 function M.init()
 	if not initialized then
 		pokedex = {}
+		pokedex_variants = {}
 		pokedex["MissingNo"] = file.load_json_from_resource("/assets/datafiles/pokemon/MissingNo.json")
 		pokedex_extra = file.load_json_from_resource("/assets/datafiles/pokedex_extra.json")
 		abilities = file.load_json_from_resource("/assets/datafiles/abilities.json")
@@ -178,8 +180,21 @@ function M.get_total_evolution_stages(pokemon)
 end
 
 
-function M.get_icon(pokemon)
-	local data = M.get_pokemon(pokemon)
+function M.get_variants(pokemon)
+	local raw = M.get_pokemon_raw(pokemon)
+	if raw.Variants then
+		local ret = {}
+		for k,_ in pairs(raw.Variants) do
+			table.insert(ret, k)
+		end
+		return ret
+	end
+	return nil
+end
+
+
+function M.get_icon(pokemon, variant)
+	local data = M.get_pokemon(pokemon, variant)
 	local sprite = M.get_sprite(pokemon)
 	if data.fakemon then
 		if data.icon and data.icon ~= "" then
@@ -205,7 +220,7 @@ function M.get_icon(pokemon)
 end
 
 
-function M.get_sprite(pokemon)
+function M.get_sprite(pokemon, variant)
 	local pokemon_index = M.get_index_number(pokemon)
 	if pokemon_index == -1 then
 		return "-1MissingNo", "pokemon0"
@@ -219,7 +234,7 @@ function M.get_sprite(pokemon)
 		return "493Arceus", "pokemon0"
 	end
 
-	local data = M.get_pokemon(pokemon)
+	local data = M.get_pokemon(pokemon, variant)
 	if data.fakemon then
 		if data.sprite and data.sprite ~= "" then
 			local path = fakemon.UNZIP_PATH .. utils.os_sep .. data.sprite 
@@ -255,18 +270,18 @@ function M.get_experience_for_level(level)
 end
 
 
-function M.get_senses(pokemon)
-	return M.get_pokemon(pokemon).Senses or {}
+function M.get_senses(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).Senses or {}
 end
 
 
-function M.get_index_number(pokemon)
-	return M.get_pokemon(pokemon).index
+function M.get_index_number(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).index
 end
 
 
-function M.get_vulnerabilities(pokemon)
-	local types = M.get_pokemon_type(pokemon)
+function M.get_vulnerabilities(pokemon, variant)
+	local types = M.get_pokemon_type(pokemon, variant)
 	return ptypes.Model(unpack(types)).vulnerabilities
 end
 
@@ -283,36 +298,36 @@ function M.get_resistances(pokemon)
 end
 
 
-function M.get_walking_speed(pokemon)
-	return M.get_pokemon(pokemon).WSp or 0
+function M.get_walking_speed(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).WSp or 0
 end
 
 
-function M.get_swimming_speed(pokemon)
-	return M.get_pokemon(pokemon).Ssp or 0
+function M.get_swimming_speed(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).Ssp or 0
 end
 
 
-function M.get_flying_speed(pokemon)
-	return M.get_pokemon(pokemon).Fsp or 0
+function M.get_flying_speed(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).Fsp or 0
 end
 
 
-function M.get_climbing_speed(pokemon)
-	return M.get_pokemon(pokemon)["Climbing Speed"] or 0
+function M.get_climbing_speed(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Climbing Speed"] or 0
 end
 
 
-function M.get_burrow_speed(pokemon)
-	return M.get_pokemon(pokemon)["Burrowing Speed"] or 0
+function M.get_burrow_speed(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Burrowing Speed"] or 0
 end
 
-function M.get_pokemon_type(pokemon)
-	return M.get_pokemon(pokemon).Type
+function M.get_pokemon_type(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).Type
 end
 
-function M.get_pokemon_size(pokemon)
-	return M.get_pokemon(pokemon).size or ""
+function M.get_pokemon_size(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).size or ""
 end
 
 function M.ability_list()
@@ -339,36 +354,36 @@ function M.get_ability_description(ability)
 end
 
 
-function M.get_hidden_ability(pokemon)
-	return M.get_pokemon(pokemon)["Hidden Ability"]
+function M.get_hidden_ability(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Hidden Ability"]
 end
 
 
-function M.get_abilities(pokemon)
-	return M.get_pokemon(pokemon).Abilities
+function M.get_abilities(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).Abilities
 end
 
 
-function M.get_skills(pokemon)
-	return M.get_pokemon(pokemon).Skill
+function M.get_skills(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).Skill
 end
 
 
-function M.get_base_hp(pokemon)
+function M.get_base_hp(pokemon, variant)
 	local min_lvl = M.get_minimum_wild_level(pokemon)
-	local con = M.get_base_attributes(pokemon).CON
+	local con = M.get_base_attributes(pokemon, variant).CON
 	local con_mod = math.floor((con - 10) / 2)
-	return M.get_pokemon(pokemon).HP - (min_lvl * con_mod)
+	return M.get_pokemon(pokemon, variant).HP - (min_lvl * con_mod)
 end
 
 
-function M.get_AC(pokemon)
-	return M.get_pokemon(pokemon).AC
+function M.get_AC(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).AC
 end
 
 
 local warning_list = {}
-function M.get_pokemon(pokemon)
+function M.get_pokemon_raw(pokemon)
 	if pokedex[pokemon] then
 		return utils.deep_copy(pokedex[pokemon])
 	else
@@ -394,9 +409,31 @@ function M.get_pokemon(pokemon)
 	end
 end
 
+function M.get_pokemon(pokemon, variant)
+	local raw = M.get_pokemon_raw(pokemon)
 
-function M.get_minimum_wild_level(pokemon)
-	return M.get_pokemon(pokemon)["MIN LVL FD"]
+	-- Default case: no variant provided, pokemon has no variants, or pokemon does not have provided variant
+	if not variant or not raw.Variants or not raw.Variants[variant] then
+		return raw
+	end
+
+	-- Alright, this pokemon has this variant, we need to get the data for this specific variant, which could have any number of overrides
+	if not pokedex_variants[pokemon] then
+		pokedex_variants[pokemon] = {}
+	end
+	if not pokedex_variants[pokemon][variant] then
+		local copy = utils.deep_copy(raw)
+		copy["Variants"] = nil
+		local diff = raw.Variants[variant].Diff
+		utils.deep_merge_into(copy, diff)
+		pokedex_variants[pokemon][variant] = copy
+	end
+	return pokedex_variants[pokemon][variant]
+end
+
+
+function M.get_minimum_wild_level(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["MIN LVL FD"]
 end
 
 
@@ -463,40 +500,41 @@ function M.evolve_points(pokemon)
 end
 
 
-function M.get_starting_moves(pokemon)
-	return M.get_pokemon(pokemon)["Moves"]["Starting Moves"]
+function M.get_starting_moves(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Moves"]["Starting Moves"]
 end
 
 
-function M.get_base_attributes(pokemon)
-	return M.get_pokemon(pokemon).attributes
+function M.get_base_attributes(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).attributes
 end
 
 
-function M.get_saving_throw_proficiencies(pokemon)
-	return M.get_pokemon(pokemon).saving_throws
+function M.get_saving_throw_proficiencies(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).saving_throws
 end
 
 
-function M.get_hit_dice(pokemon)
-	return M.get_pokemon(pokemon)["Hit Dice"]
+function M.get_hit_dice(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Hit Dice"]
 end
 
 
-function M.get_HM_numbers(pokemon)
-	return M.get_pokemon(pokemon)["Moves"].HM
+function M.get_HM_numbers(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Moves"].HM
 end
 
 
-function M.get_TM_numbers(pokemon)
-	return M.get_pokemon(pokemon)["Moves"].TM
+function M.get_TM_numbers(pokemon, variant)
+	return M.get_pokemon(pokemon, variant)["Moves"].TM
 end
 
 
-function M.get_move_machines(pokemon)
+function M.get_move_machines(pokemon, variant)
 	local move_list = {}
-	if M.get_pokemon_TM_numbers(pokemon) then
-		for _, n in pairs(M.get_pokemon_TM_numbers(pokemon)) do
+	local tm_numbers = M.get_pokemon_TM_numbers(pokemon, variant)
+	if tm_numbers then
+		for _, n in pairs(tm_numbers) do
 			table.insert(move_list, movedex.get_TM(n))
 		end
 	end
@@ -504,8 +542,8 @@ function M.get_move_machines(pokemon)
 end
 
 
-function M.get_SR(pokemon)
-	return M.get_pokemon(pokemon).SR
+function M.get_SR(pokemon, variant)
+	return M.get_pokemon(pokemon, variant).SR
 end
 
 
@@ -514,7 +552,7 @@ function M.get_exp_worth(level, sr)
 end
 
 
-function M.get_moves(pokemon, level)
+function M.get_moves(pokemon, variant, level)
 	level = level or 20
 	local moves = M.get_pokemon(pokemon)["Moves"]
 	local pick_from = utils.shallow_copy(moves["Starting Moves"])

--- a/pokedex/pokemon.lua
+++ b/pokedex/pokemon.lua
@@ -37,6 +37,8 @@ local feat_to_attribute = {
 	Acrobat="DEX"
 }
 
+local LATEST_POKEMON_VERSION = 2
+
 M.GENDERLESS = pokedex.GENDERLESS
 M.MALE = pokedex.MALE
 M.FEMALE = pokedex.FEMALE
@@ -1045,6 +1047,36 @@ local function get_starting_moves(pkmn, number_of_moves)
 end
 
 
+function M.upgrade_pokemon(pkmn)
+	local version = pkmn and pkmn.version or 1
+
+	local needs_upgrade = version ~= LATEST_POKEMON_VERSION
+
+	if needs_upgrade then
+		for i=version,LATEST_POKEMON_VERSION-1 do
+			if false then
+
+				-- NOTE: If a new data upgrade is needed, update the above LATEST_POKEMON_VERSION value and add a new block here like so:
+				--elseif i == ??? then
+
+			elseif i == 1 then
+
+				-- Any pokemon whose species includes variants (Pumkpaboo and Gourgeist) needs to have its current variant set to the default
+				-- variant (Small). NOTE: If tuture variants are added, another version upgrade will be required to upgrade those.
+				if not pkmn.variant then
+					pkmn.variant = pokedex.get_default_variant(M.get_current_species(pkmn))
+				end
+				
+			else
+				assert(false, "Unknown pokemon data version " .. pkmn.version)
+			end
+		end
+
+		pkmn.version = LATEST_POKEMON_VERSION
+	end
+end
+
+
 function M.new(data)
 	local this = {}
 	this.species = {}
@@ -1078,6 +1110,8 @@ function M.new(data)
 	this.hp.edited = false
 
 	this.moves = get_starting_moves(this, data.number_of_moves)
+
+	this.version = LATEST_POKEMON_VERSION
 	
 	return this
 end

--- a/pokedex/pokemon.lua
+++ b/pokedex/pokemon.lua
@@ -167,7 +167,7 @@ end
 
 
 function M.get_attributes(pkmn)
-	local base = pokedex.get_base_attributes(M.get_caught_species(pkmn))
+	local base = pokedex.get_base_attributes(M.get_caught_species(pkmn), pkmn.variant)
 	local increased = M.get_increased_attributes(pkmn) or {}
 	local added = M.get_added_attributes(pkmn) or {}
 	local natures = natures.get_nature_attributes(M.get_nature(pkmn)) or {}
@@ -476,9 +476,9 @@ function M.get_defaut_max_hp(pkmn)
 		evolutions = get_evolved_at_level(pkmn)
 		local hit_dice = pokedex.get_hit_dice(M.get_current_species(pkmn))
 		local hit_dice_avg = math.ceil((hit_dice + 1) / 2)
-		return pokedex.get_base_hp(caught) + evolution_hp + ((M.get_current_level(pkmn) - evolutions[#evolutions]) * hit_dice_avg)
+		return pokedex.get_base_hp(caught, pkmn.variant) + evolution_hp + ((M.get_current_level(pkmn) - evolutions[#evolutions]) * hit_dice_avg)
 	else
-		local base = pokedex.get_base_hp(current)
+		local base = pokedex.get_base_hp(current, pkmn.variant)
 		local from_level = M.get_caught_level(pkmn)
 		local hit_dice = pokedex.get_hit_dice(current)
 		local levels_gained = at_level - from_level
@@ -1026,7 +1026,7 @@ end
 local function get_starting_moves(pkmn, number_of_moves)
 	-- We get all moves
 	local number_of_moves = number_of_moves or 4
-	local starting_moves = pokedex.get_starting_moves(M.get_current_species(pkmn))
+	local starting_moves = pokedex.get_starting_moves(M.get_current_species(pkmn), pkmn.variant)
 
 	-- Shuffle the moves around, we want random moves
 	if #starting_moves > number_of_moves then
@@ -1050,9 +1050,10 @@ function M.new(data)
 	this.species = {}
 	this.species.caught = data.species
 	this.species.current = data.species
+	this.variant = data.variant
 
 	this.level = {}
-	this.level.caught = pokedex.get_minimum_wild_level(this.species.caught)
+	this.level.caught = pokedex.get_minimum_wild_level(this.species.caught, this.variant)
 	this.level.current = this.level.caught
 	this.level.evolved = {}
 
@@ -1062,7 +1063,7 @@ function M.new(data)
 	this.nature = "No Nature"
 
 	this.feats = {}
-	this.abilities = pokedex.get_abilities(data.species)
+	this.abilities = pokedex.get_abilities(data.species, data.variant)
 
 	this.exp = pokedex.get_experience_for_level(this.level.caught-1)
 
@@ -1072,8 +1073,8 @@ function M.new(data)
 	local con_mod = math.floor((con - 10) / 2)
 
 	this.hp = {}
-	this.hp.max = pokedex.get_base_hp(data.species)
-	this.hp.current = pokedex.get_base_hp(data.species) + this.level.current * math.floor((M.get_attributes(this).CON - 10) / 2)
+	this.hp.max = pokedex.get_base_hp(data.species, data.variant)
+	this.hp.current = pokedex.get_base_hp(data.species, data.variant) + this.level.current * math.floor((M.get_attributes(this).CON - 10) / 2)
 	this.hp.edited = false
 
 	this.moves = get_starting_moves(this, data.number_of_moves)

--- a/pokedex/storage.lua
+++ b/pokedex/storage.lua
@@ -4,6 +4,7 @@ local md5 = require "utils.md5"
 local utils = require "utils.utils"
 local profiles = require "pokedex.profiles"
 local pokedex = require "pokedex.pokedex"
+local _pokemon = require "pokedex.pokemon"
 local log = require "utils.log"
 
 local M = {}
@@ -142,7 +143,9 @@ end
 
 function M.get_copy(id)
 	if player_pokemon[id] then
-		return utils.deep_copy(player_pokemon[id])
+		local pkmn = player_pokemon[id]
+		_pokemon.upgrade_pokemon(pkmn)
+		return utils.deep_copy(pkmn)
 	else
 		local e = string.format("Trying to get '" .. tostring(id) .. "' from storage\n\n%s", debug.traceback())
 		gameanalytics.addErrorEvent {
@@ -156,7 +159,9 @@ end
 
 
 local function get(id)
-	return player_pokemon[id]
+	local pkmn = player_pokemon[id]
+	_pokemon.upgrade_pokemon(pkmn)
+	return pkmn
 end
 
 
@@ -221,6 +226,8 @@ end
 
 
 function M.add(pokemon)
+	_pokemon.upgrade_pokemon(pokemon)
+	
 	for i=#pokemon.moves, 1, -1 do
 		if pokemon.moves[i] == "" or pokemon.moves[i] == "None" then
 			table.remove(pokemon.moves, i)

--- a/screens/change_pokemon/add/add.gui_script
+++ b/screens/change_pokemon/add/add.gui_script
@@ -12,6 +12,7 @@ local gooey = require "gooey.gooey"
 local notify = require "utils.notify"
 local dex = require "pokedex.dex"
 local screens = require "utils.screens"
+local messages = require "utils.messages"
 
 local HAVE_EVOLVED = false
 
@@ -64,7 +65,7 @@ function init(self)
 	end
 	
 	button.register("change_pokemon/btn_species", function()
-		monarch.show(screens.SCROLLIST, {}, {items=pokedex.list, message_id="species", sender=msg.url(), title="Pick your Pokemon"})
+		monarch.show(screens.SCROLLIST, {}, {items=pokedex.list, message_id=messages.SPECIES, sender=msg.url(), title="Pick your Pokemon"})
 	end)
 	
 	if storage.is_party_full() then

--- a/screens/change_pokemon/move/scrollist.gui_script
+++ b/screens/change_pokemon/move/scrollist.gui_script
@@ -54,19 +54,19 @@ local function set_all_moves(self)
 end
 
 local function set_current(self)
-	self.all_items = filter_out_current_moves(self, pokedex.get_moves(self.species, self.level))
+	self.all_items = filter_out_current_moves(self, pokedex.get_moves(self.species, self.variant, self.level))
 	refresh_list(self)
 end
 
 
 local function set_max(self)
-	self.all_items = filter_out_current_moves(self, pokedex.get_moves(self.species, 20))
+	self.all_items = filter_out_current_moves(self, pokedex.get_moves(self.species, self.variant, 20))
 	refresh_list(self)
 end
 
 
 local function set_hm_tm(self)
-	self.all_items = filter_out_current_moves(self,  pokedex.get_move_machines(self.species))
+	self.all_items = filter_out_current_moves(self,  pokedex.get_move_machines(self.species, self.variant))
 	refresh_list(self)
 end
 
@@ -81,8 +81,9 @@ function init(self)
 	self.current_moves = d.current_moves
 	self.move_to_replace = d.move_to_replace
 	self.pokemon = d.pokemon
+	self.variant = d.pokemon.variant
 	self.sub_list = "current"	
-	local starting_moves = pokedex.get_moves(self.species, self.level)
+	local starting_moves = pokedex.get_moves(self.species, self.variant, self.level)
 	self.all_items = filter_out_current_moves(self, starting_moves)
 	self.list_items = utils.shallow_copy(self.all_items)
 	gui.set_text(gui.get_node("scrollist/topbar/title"), "Choose New Move")

--- a/screens/generate_pokemon/generate_pokemon.gui_script
+++ b/screens/generate_pokemon/generate_pokemon.gui_script
@@ -362,7 +362,7 @@ function on_input(self, action_id, action)
 	gooey.button("btn_add", action_id, action, function()
 		for p, _ in pairs(selected_pokemon) do
 			local level = self.level == 0 and pokedex.get_minimum_wild_level(p) or self.level
-			generate.add_pokemon(p, level)
+			generate.add_pokemon(p, self.variant, level)
 		end
 		selected_pokemon = {}
 	end, function(b) gooey_buttons.common_button(b, gui.get_node("txt_add")) end)
@@ -370,6 +370,13 @@ function on_input(self, action_id, action)
 	gooey.button("btn_random", action_id, action, function()
 		local index = rnd.range(1, #self.filtered_pokemons)
 		local species = self.filtered_pokemons[index]
-		monarch.show(screens.RANDOM_POKEMON, {}, {species=species, level=self.level, pokemons=self.filtered_pokemons})
+
+		local variants = pokedex.get_variants(species)
+		local variant = nil
+		if variants and #variants > 0 then
+			variant = variants[rnd.range(1, #variants)]
+		end
+		
+		monarch.show(screens.RANDOM_POKEMON, {}, {species=species, level=self.level, variant=variant, pokemons=self.filtered_pokemons})
 	end, function(b) gooey_buttons.common_button(b, gui.get_node("txt_random")) end)
 end

--- a/screens/generate_pokemon/generate_pokemon.lua
+++ b/screens/generate_pokemon/generate_pokemon.lua
@@ -9,11 +9,11 @@ local dex = require "pokedex.dex"
 
 local M = {}
 
-function M.add_pokemon(species, level)
+function M.add_pokemon(species, variant, level)
 	notify.notify(species .. " was added to your team!")
-	local all_moves = utils.shuffle2(utils.merge(pokedex.get_starting_moves(species), pokedex.get_moves(species, level)))
+	local all_moves = utils.shuffle2(utils.merge(pokedex.get_starting_moves(species), pokedex.get_moves(species, variant, level)))
 
-	local pokemon = _pokemon.new({species=species})
+	local pokemon = _pokemon.new({species=species, variant=variant})
 	local moves = {}
 	for i=1, 4 do
 		if all_moves[i] then

--- a/screens/generate_pokemon/random_pokemon/random_pokemon.gui_script
+++ b/screens/generate_pokemon/random_pokemon/random_pokemon.gui_script
@@ -9,7 +9,11 @@ local function update_pokemon(self)
 	gui.set_texture(gui.get_node("pokemon_sprite"), texture)
 	gui.play_flipbook(gui.get_node("pokemon_sprite"), sprite)
 	local level = self.level == 0 and pokedex.get_minimum_wild_level(self.species) or self.level
-	gui.set_text(gui.get_node("txt_pokemon"), self.species:upper() .. "\nLv. " .. level)
+	local species_text = self.species
+	if self.variant then
+		species_text = species_text .. " - " .. self.variant
+	end
+	gui.set_text(gui.get_node("txt_pokemon"), species_text:upper() .. "\nLv. " .. level)
 end
 
 function init(self)
@@ -18,6 +22,7 @@ function init(self)
 	self.pokemons = data.pokemons
 	self.species = data.species
 	self.level = data.level
+	self.variant = data.variant
 	
 	update_pokemon(self)
 end
@@ -30,12 +35,18 @@ function on_input(self, action_id, action)
 	local a = gooey.button("btn_random", action_id, action, function()
 		local index = rnd.range(1, #self.pokemons)
 		self.species = self.pokemons[index]
+		local variants = pokedex.get_variants(self.species)
+		if variants and #variants > 0 then
+			self.variant = variants[rnd.range(1, #variants)]
+		else
+			self.variant = nil
+		end
 		update_pokemon(self)
 	end, function(b) gooey_buttons.common_button(b, gui.get_node("txt_random")) end)
 
 	local b = gooey.button("btn_add", action_id, action, function()
 		local level = self.level == 0 and pokedex.get_minimum_wild_level(self.species) or self.level
-		generate.add_pokemon(self.species, level)
+		generate.add_pokemon(self.species, self.variant, level)
 	end, function(b) gooey_buttons.common_button(b, gui.get_node("txt_add")) end)
 
 	local c = gooey.button("btn_back", action_id, action, back)

--- a/screens/generate_pokemon/random_pokemon/random_pokemon.gui_script
+++ b/screens/generate_pokemon/random_pokemon/random_pokemon.gui_script
@@ -9,10 +9,7 @@ local function update_pokemon(self)
 	gui.set_texture(gui.get_node("pokemon_sprite"), texture)
 	gui.play_flipbook(gui.get_node("pokemon_sprite"), sprite)
 	local level = self.level == 0 and pokedex.get_minimum_wild_level(self.species) or self.level
-	local species_text = self.species
-	if self.variant then
-		species_text = species_text .. " - " .. self.variant
-	end
+	local species_text = pokedex.get_species_display(self.species, self.variant)
 	gui.set_text(gui.get_node("txt_pokemon"), species_text:upper() .. "\nLv. " .. level)
 end
 

--- a/screens/party/components/information.lua
+++ b/screens/party/components/information.lua
@@ -12,6 +12,7 @@ local scrollhandler = require "screens.party.components.scrollhandler"
 local constants = require "utils.constants"
 local screens = require "utils.screens"
 local messages = require "utils.messages"
+local pokedex = require "pokedex.pokedex"
 
 local M = {}
 local active = {}
@@ -36,10 +37,7 @@ local function setup_main_information(nodes, pokemon)
 		gui.play_flipbook(nodes["pokemon/pokemon_sprite"], pokemon_sprite)
 	end
 
-	local species_text = species
-	if pokemon.variant then
-		species_text = species .. " - " .. pokemon.variant
-	end
+	local species_text = pokedex.get_species_display(species, pokemon.variant)
 	gui.set_text(nodes["pokemon/index"], string.format("#%03d %s", _pokemon.get_index_number(pokemon), species_text))
 	
 	gui.set_text(nodes["pokemon/species"], nickname)

--- a/screens/party/components/information.lua
+++ b/screens/party/components/information.lua
@@ -36,7 +36,11 @@ local function setup_main_information(nodes, pokemon)
 		gui.play_flipbook(nodes["pokemon/pokemon_sprite"], pokemon_sprite)
 	end
 
-	gui.set_text(nodes["pokemon/index"], string.format("#%03d %s", _pokemon.get_index_number(pokemon), species))
+	local species_text = species
+	if pokemon.variant then
+		species_text = species .. " - " .. pokemon.variant
+	end
+	gui.set_text(nodes["pokemon/index"], string.format("#%03d %s", _pokemon.get_index_number(pokemon), species_text))
 	
 	gui.set_text(nodes["pokemon/species"], nickname)
 	gui.set_text(nodes["pokemon/level"], "Lv. " ..  _pokemon.get_current_level(pokemon))

--- a/screens/popups/transfer_pokemon/transfer.gui_script
+++ b/screens/popups/transfer_pokemon/transfer.gui_script
@@ -194,13 +194,17 @@ local function setup_info(self)
 	update_hp_meter(m, c)
 	
 	self.nickname = _pokemon.get_nickname(pokemon)
-	local species = _pokemon.get_current_species(pokemon):upper()
-	if self.nickname then
-		gui.set_text(gui.get_node("txt_index"), string.format("#%03d", _pokemon.get_index_number(pokemon)) .. " " .. species)
+	local species = _pokemon.get_current_species(pokemon)
+	if self.nickname or pokemon.variant then
+		local species_text = species
+		if pokemon.variant then
+			species_text = species_text .. " - " .. pokemon.variant
+		end
+		gui.set_text(gui.get_node("txt_index"), string.format("#%03d", _pokemon.get_index_number(pokemon)) .. " " .. species_text)
 	else
 		gui.set_text(gui.get_node("txt_index"), string.format("#%03d", _pokemon.get_index_number(pokemon)))
 	end
-	self.nickname = self.nickname or species
+	self.nickname = self.nickname or species:upper()
 	gui.set_text(gui.get_node("txt_species"), self.nickname)
 	gui_utils.scale_text_to_fit_size(gui.get_node("txt_species"))
 	

--- a/screens/popups/transfer_pokemon/transfer.gui_script
+++ b/screens/popups/transfer_pokemon/transfer.gui_script
@@ -195,11 +195,8 @@ local function setup_info(self)
 	
 	self.nickname = _pokemon.get_nickname(pokemon)
 	local species = _pokemon.get_current_species(pokemon)
-	if self.nickname or pokemon.variant then
-		local species_text = species
-		if pokemon.variant then
-			species_text = species_text .. " - " .. pokemon.variant
-		end
+	local species_text = pokedex.get_species_display(species, pokemon.variant)
+	if self.nickname or species ~= species_text then		
 		gui.set_text(gui.get_node("txt_index"), string.format("#%03d", _pokemon.get_index_number(pokemon)) .. " " .. species_text)
 	else
 		gui.set_text(gui.get_node("txt_index"), string.format("#%03d", _pokemon.get_index_number(pokemon)))

--- a/utils/messages.lua
+++ b/utils/messages.lua
@@ -41,6 +41,7 @@ M.SHOW_SPLASH = hash("show_splash")
 -- Change Pokemon
 M.NATURE = hash("nature")
 M.SPECIES = hash("species")
+M.VARIANT = hash("variant")
 M.EVOLVE = hash("evolve")
 M.ABILITIES = hash("abilities")
 M.FEATS = hash("feats")


### PR DESCRIPTION
…n time. These variants can adjust most of the properties pokemon may have. The only ones tested so far are Pumpkaboo and Gourgeist, and their only adjustable properties are DEX and CON, so not all possible variant manipulations are tested with this change.

Existing Pumpkaboo or Gourgeist are not retroactively granted variants, but their stats are equivalent to the default (which is Small).
Future enhancements could include:
* Extending certain variants to be choosable after creation (for pokemon this works for), such as a pokemon that changes forms based on moves
* Adding Alolan or Galarian variants
* Refactoring existing pokemon that currently have built-in variant types, such as Wormadam or Rotom. These were already supported by the app so I didn't want to have this first pass change them (as it would require a data shift).
Fixes #523