### PR TITLE
Adding a move now properly updates the evolve button

### DIFF
--- a/pokedex/pokedex.lua
+++ b/pokedex/pokedex.lua
@@ -435,6 +435,10 @@ function M.get_evolution_possible(pokemon, gender, moves)
 	return (d and (d.level or move_allow) and gender_allow) and true or false
 end
 
+function M.get_species_can_evolve(pokemon)
+	local d = M.get_evolution_data(pokemon)
+	return d and d.into and next(d.into) ~= nil
+end
 
 function M.get_evolution_level(pokemon)
 	local d = M.get_evolution_data(pokemon)

--- a/pokedex/pokemon.lua
+++ b/pokedex/pokemon.lua
@@ -868,6 +868,10 @@ function M.get_exp_worth(pkmn)
 	return pokedex.get_exp_worth(level, sr)
 end
 
+function M.get_species_can_evolve(pkmn)
+	return pokedex.get_species_can_evolve(M.get_current_species(pkmn))
+end
+
 function M.get_evolution_possible(pkmn)
 	return pokedex.get_evolution_possible(M.get_current_species(pkmn), M.get_gender(pkmn), M.get_moves(pkmn)) and not M.get_consumed_eviolite(pkmn)
 end

--- a/screens/change_pokemon/edit/edit.gui_script
+++ b/screens/change_pokemon/edit/edit.gui_script
@@ -38,7 +38,6 @@ local function evolve(self, species)
 	end)
 end
 
-
 function init(self)
 	self.evolve_button_active = false
 
@@ -52,30 +51,24 @@ function init(self)
 	
 	pokemon_image(_pokemon.get_current_species(self.pokemon))
 	gui.set_enabled(gui.get_node("change_pokemon/cursor"), false)
-	
-	local consumed_eviolite = _pokemon.get_consumed_eviolite(self.pokemon)
-	local evolution_possible = _pokemon.get_evolution_possible(self.pokemon)
-	local evolution_level = evolution_possible and _pokemon.get_evolution_level(self.pokemon)
+
 	self.nickname = _pokemon.get_nickname(self.pokemon)
 	self.evolve_button = gui.get_node("btn_evolve")
 	
-	
+	local consumed_eviolite = _pokemon.get_consumed_eviolite(self.pokemon)
 	gui.set_enabled(gui.get_node("change_pokemon/checkmark_eviolite_mark"), consumed_eviolite)
 	gooey.checkbox("change_pokemon/bg_eviolite").set_checked(consumed_eviolite)
 	
-	if not evolution_possible then
+	if not _pokemon.get_species_can_evolve(self.pokemon) then
 		gui.set_enabled(self.evolve_button, false)
-	
-	elseif evolution_possible and not consumed_eviolite and evolution_level <= _pokemon.get_current_level(self.pokemon) then
-		self.evolve_button_active = true
-		gui.set_enabled(self.evolve_button, true)
-		gui.set_color(gui.get_node("txt_evolve"), gui_colors.BUTTON_TEXT)
-		gui.play_flipbook(self.evolve_button, "common_up")
 	end
-	
+
 	function self.redraw(self)
+		local evolution_possible = _pokemon.get_evolution_possible(self.pokemon)
+		local evolution_level = evolution_possible and _pokemon.get_evolution_level(self.pokemon)
 		if not _pokemon.get_consumed_eviolite(self.pokemon) and evolution_possible and evolution_level <= _pokemon.get_current_level(self.pokemon) then
 			self.evolve_button_active = true
+			--gui.set_enabled(self.evolve_button, true)
 			gui.set_color(gui.get_node("txt_evolve"), gui_colors.BUTTON_TEXT)
 			gui.play_flipbook(self.evolve_button, "common_up")
 		else
@@ -88,6 +81,9 @@ function init(self)
 	button.register("change_pokemon/txt_max_hp", function()
 		monarch.show(screens.ARE_YOU_SURE, nil, {sender=msg.url(), text="Reset HP and let the App controll it for you", title="Reset", id=messages.RESET})
 	end)
+
+	-- Update evolution button states
+	self.redraw(self)
 end
 
 function final(self)


### PR DESCRIPTION
You can now see the Evolve button on Pokemon that evolve based on moves. The move button is also now enabled if the required move is added.