### PR TITLE
Now displays the skill mod next to the skills. 

### DIFF
--- a/pokedex/pokedex.lua
+++ b/pokedex/pokedex.lua
@@ -31,10 +31,24 @@ M.VARIANT_CREATE_MODE_DEFAULT = "default"
 M.VARIANT_CREATE_MODE_CHOOSE = "choose"
 
 M.skills = {
-	'Acrobatics', 'Animal Handling', 'Arcana', 'Athletics',
-	'Deception', 'History', 'Insight', 'Intimidation',
-	'Investigation', 'Medicine', 'Nature', 'Perception', 'Performance',
-	'Persuasion', 'Religion', 'Sleight of Hand', 'Stealth', 'Survival'
+	['Acrobatics'] = "DEX",
+	['Animal Handling'] = "WIS",
+	['Arcana'] = "INT",
+	['Athletics'] = "STR",
+	['Deception'] = "CHA",
+	['History'] = "INT",
+	['Insight'] = "WIS",
+	['Intimidation'] = "CHA",
+	['Investigation'] = "INT",
+	['Medicine'] = "WIS",
+	['Nature'] = "INT",
+	['Perception'] = "WIS",
+	['Performance'] = "CHA",
+	['Persuasion'] = "CHA",
+	['Religion'] = "INT",
+	['Sleight of Hand'] = "DEX",
+	['Stealth'] = "DEX",
+	['Survival'] = "WIS"
 }
 
 local initialized = false

--- a/pokedex/pokemon.lua
+++ b/pokedex/pokemon.lua
@@ -641,6 +641,22 @@ function M.get_abilities(pkmn, as_raw)
 	return t
 end
 
+function M.get_skills_modifier(pkmn)
+	local prof = M.get_proficency_bonus(pkmn)
+	local proficencies = M.get_skills(pkmn)
+	local attributes = M.get_attributes(pkmn)
+	local tbl = {}
+	for _, skill in pairs(proficencies) do
+		tbl[skill] = math.floor((attributes[pokedex.skills[skill]] - 10) / 2) + prof
+	end
+	for skill, mod in pairs(pokedex.skills) do
+		if tbl[skill] == nil then
+			tbl[skill] = math.floor((attributes[pokedex.skills[skill]] - 10) / 2)
+		end
+	end
+	return tbl
+end
+
 function M.remove_skill(pkmn, position)
 	table.remove(pkmn.skills, position)
 end

--- a/screens/change_pokemon/change_pokemon.lua
+++ b/screens/change_pokemon/change_pokemon.lua
@@ -638,7 +638,7 @@ local function add_skill(self)
 	local skill_list = utils.deep_copy(pokedex.skills)
 	local filtered = {}
 	local add
-	for _, a_skill in pairs(skill_list) do 
+	for a_skill, _ in pairs(skill_list) do 
 		add = true
 		for _, skill in pairs(_pokemon.get_skills(self.pokemon)) do
 			if a_skill == skill then

--- a/screens/party/components/information.lua
+++ b/screens/party/components/information.lua
@@ -210,7 +210,7 @@ function M.create(nodes, pokemon, index)
 	skills_button = nil
 	active = nodes
 	active_pokemon = pokemon
-	pprint(active)
+
 	rest_button = gui.get_id(active["pokemon/btn_rest"])
 	setup_main_information(nodes, pokemon)
 	setup_info_tab(nodes, pokemon)

--- a/screens/party/components/information.lua
+++ b/screens/party/components/information.lua
@@ -23,6 +23,7 @@ local POKEMON_SPECIES_TEXT_SCALE = vmath.vector3(1.5)
 local item_button
 local rest_button
 local active_pokemon
+local skills_button
 
 
 local function setup_main_information(nodes, pokemon)
@@ -94,13 +95,14 @@ local function setup_info_tab(nodes, pokemon)
 
 	local skill_string = ""
 	local skills = _pokemon.get_skills(pokemon)
+	local skills_attributes = _pokemon.get_skills_modifier(pokemon)
 	if #skills > 8 then
 		for _, skill in pairs(skills) do
-			skill_string = skill_string .. skill .. ", "
+			skill_string = skill_string .. skill .. " (" .. skills_attributes[skill] .. ") , "
 		end
 	else
 		for _, skill in pairs(skills) do
-			skill_string = skill_string .. "• " .. skill .. "\n"
+			skill_string = skill_string .. "• " .. skill .. " (" .. skills_attributes[skill] .. ")\n"
 		end
 	end
 	gui.set_text(nodes["pokemon/traits/txt_skills"], skill_string)
@@ -166,6 +168,18 @@ local function setup_info_tab(nodes, pokemon)
 	else
 		gui.set_enabled(nodes["pokemon/gender_icon"], false)
 	end
+
+	skills_button = party_utils.set_id(nodes["pokemon/traits/skills_details"])
+end
+
+local function show_skill_list()
+	local skill_list = utils.deep_copy(pokedex.skills)
+	local tbl = {}
+	local add
+	for skill, value in pairs(_pokemon.get_skills_modifier(active_pokemon)) do 
+		tbl[#tbl+1] = skill .. " (" .. value .. ")"
+	end
+	monarch.show(screens.SCROLLIST, {}, {items=tbl, message_id=messages.SKILLS, sender=msg.url(), title="Skills"})
 end
 
 function M.on_input(action_id, action)
@@ -183,12 +197,20 @@ function M.on_input(action_id, action)
 	gooey.button(rest_button, action_id, action, function() 
 		monarch.show(screens.ARE_YOU_SURE, nil, {title="Pokémon Center", text="We heal your Pokémon back to perfect health!\nShall we heal your Pokémon?", sender=msg.url(), id=messages.FULL_REST})
 	end)
+	
+	if skills_button then
+		gooey.button(skills_button, action_id, action, function() 
+			show_skill_list()
+		end)
+	end
 end
 
 function M.create(nodes, pokemon, index)
 	item_button = nil
+	skills_button = nil
 	active = nodes
 	active_pokemon = pokemon
+	pprint(active)
 	rest_button = gui.get_id(active["pokemon/btn_rest"])
 	setup_main_information(nodes, pokemon)
 	setup_info_tab(nodes, pokemon)

--- a/screens/party/party.gui
+++ b/screens/party/party.gui
@@ -2953,6 +2953,61 @@ nodes {
     w: 1.0
   }
   size {
+    x: 206.0
+    y: 208.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.9254902
+    y: 0.56078434
+    z: 0.09411765
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/trait_border"
+  id: "pokemon/traits/backing"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_N
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "pokemon/traits/skills_backing"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 5.0
+    y: 5.0
+    z: 5.0
+    w: 5.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: -3.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
     x: 200.0
     y: 202.0
     z: 0.0
@@ -2972,7 +3027,7 @@ nodes {
   yanchor: YANCHOR_NONE
   pivot: PIVOT_N
   adjust_mode: ADJUST_MODE_FIT
-  parent: "pokemon/traits/skills_backing"
+  parent: "pokemon/traits/backing"
   layer: "gui"
   inherit_alpha: true
   slice9 {

--- a/templates/party_pokemon.gui
+++ b/templates/party_pokemon.gui
@@ -2583,6 +2583,61 @@ nodes {
     w: 1.0
   }
   size {
+    x: 206.0
+    y: 208.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.9254902
+    y: 0.56078434
+    z: 0.09411765
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/trait_border"
+  id: "traits/backing"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_N
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "traits/skills_backing"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 5.0
+    y: 5.0
+    z: 5.0
+    w: 5.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: -3.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
     x: 200.0
     y: 202.0
     z: 0.0
@@ -2602,7 +2657,7 @@ nodes {
   yanchor: YANCHOR_NONE
   pivot: PIVOT_N
   adjust_mode: ADJUST_MODE_FIT
-  parent: "traits/skills_backing"
+  parent: "traits/backing"
   layer: "gui"
   inherit_alpha: true
   slice9 {

--- a/templates/pokemon_info.gui
+++ b/templates/pokemon_info.gui
@@ -2256,6 +2256,61 @@ nodes {
     w: 1.0
   }
   size {
+    x: 206.0
+    y: 208.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 0.9254902
+    y: 0.56078434
+    z: 0.09411765
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "gui/trait_border"
+  id: "backing"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_N
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "skills_backing"
+  layer: "gui"
+  inherit_alpha: true
+  slice9 {
+    x: 5.0
+    y: 5.0
+    z: 5.0
+    w: 5.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  template_node_child: false
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: -3.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
     x: 200.0
     y: 202.0
     z: 0.0
@@ -2275,7 +2330,7 @@ nodes {
   yanchor: YANCHOR_NONE
   pivot: PIVOT_N
   adjust_mode: ADJUST_MODE_FIT
-  parent: "skills_backing"
+  parent: "backing"
   layer: "gui"
   inherit_alpha: true
   slice9 {


### PR DESCRIPTION
By clicking on the skill window (which now have an orange outline to indicate that you can click it) you bring up a list view with all skills

![2020-11-29 15_51_00-Window](https://user-images.githubusercontent.com/5273682/100545142-c5afa480-325a-11eb-9518-2c6ba88abff8.png)
![2020-11-29 15_51_22-Window](https://user-images.githubusercontent.com/5273682/100545141-c5170e00-325a-11eb-9c7d-0ae10c5387ea.png)


Simply reusing the normal scroll window. Maybe I shouldn't be lazy and create a new? In particular the thing that isn't great is that the backing of the items have an orange outline indicating that you can interact with them. 